### PR TITLE
ci: Add `typings/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ Untitled*.ipynb
 
 # hatch, doc generation
 data.json
+
+# type stubs
+typings/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@
 
 2. Make certain your branch is in sync with head:
  
-       git pull upstream main
+       git pull origin main
 
 3. Do a clean doc build:
 
@@ -25,13 +25,13 @@
 5. Commit change and push to main:
 
        git add . -u
-       git commit -m "chore: bump version to 5.0.0"
-       git push upstream main
+       git commit -m "chore: Bump version to 5.0.0"
+       git push origin main
 
 6. Tag the release:
 
        git tag -a v5.0.0 -m "version 5.0.0 release"
-       git push upstream v5.0.0
+       git push origin v5.0.0
 
 7. Build source & wheel distributions:
 
@@ -54,11 +54,11 @@
 11. Commit change and push to main:
 
         git add . -u
-        git commit -m "chore: bump version to 5.1.0dev"
-        git push upstream main
+        git commit -m "chore: Bump version to 5.1.0dev"
+        git push origin main
 
 12. Double-check that a conda-forge pull request is generated from the updated
-    pip package by the conda-forge bot (may take up to ~an hour):
+    pip package by the conda-forge bot (may take up to several hours):
     https://github.com/conda-forge/altair-feedstock/pulls
 
 13. Publish a new release in https://github.com/vega/altair/releases/

--- a/tests/examples_methods_syntax/cumulative_count_chart.py
+++ b/tests/examples_methods_syntax/cumulative_count_chart.py
@@ -17,5 +17,5 @@ alt.Chart(source).transform_window(
     sort=[{"field": "IMDB_Rating"}],
 ).mark_area().encode(
     x="IMDB_Rating:Q",
-    y=alt.Y("cumulative_count:Q", stack=False)
+    y=alt.Y("cumulative_count:Q").stack(False)
 )


### PR DESCRIPTION
Related https://github.com/vega/vl-convert/issues/184

Using this directory for type stubs, which is a temporary solve for the `vl_convert` issue

![image](https://github.com/user-attachments/assets/66396adb-02b6-46ac-b5b8-93e7aa61c73e)
